### PR TITLE
Added basic taxonomy support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,3 +17,9 @@ copyright = "Scott D Hodgson"
     languageName = "Français"
     contentDir = "content/fr"    
     weight = 2
+[languages.en.taxonomies]
+  tag = "tags"
+  category = "categories"
+  hardware = "hardware"
+  software = "software"
+[languages.fr.taxonomies]

--- a/content/en/challenges/001.md
+++ b/content/en/challenges/001.md
@@ -1,5 +1,8 @@
 ---
 title: "001"
 date: 2018-10-20T22:53:10-04:00
+hardware: ["Raspberry Pi"]
+software: ["Raspbian", "Hugo", "Apache"]
 ---
 
+test

--- a/themes/bootstrap/layouts/_default/single.html
+++ b/themes/bootstrap/layouts/_default/single.html
@@ -9,6 +9,7 @@
   <div class="container-fluid">
     <h1>{{ .Title }}</h1>
     {{ .Content }}
+    {{ partial "taxonomy.html" . }}
   </div>
 </body>
 </html>

--- a/themes/bootstrap/layouts/partials/taxonomy.html
+++ b/themes/bootstrap/layouts/partials/taxonomy.html
@@ -1,0 +1,12 @@
+{{ range $taxonomyname, $taxonomy := .Site.Taxonomies }}
+  <ul>
+    {{ range $key, $value := $taxonomy }}
+    <li><a href="{{ "/" | relLangURL}}{{ $taxonomyname | urlize | lower }}/{{ $key | urlize | lower }}">{{ $key }} ({{ len $value }})</a></li>
+          <ul>
+          {{ range $value.Pages }}
+              <li><a href="{{ .Permalink}}"> {{ .LinkTitle }} ({{ len $value.Pages }})</a> </li>
+          {{ end }}
+          </ul>
+    {{ end }}
+  </ul>
+{{ end }}


### PR DESCRIPTION
Added the basic taxonomy support.  Ideally the taxonomy partial will need to be able to detect the current page to filter the items in the long-run.  This is a step in that direction.